### PR TITLE
Deprecate old image tags; ci automation

### DIFF
--- a/.github/workflows/delete-old-tags.yml
+++ b/.github/workflows/delete-old-tags.yml
@@ -1,0 +1,25 @@
+name: delete_expired_image_tags
+
+on:
+  push:
+    branches:
+      - 'master'
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  delete_tags:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker Hub Tag Deleter
+        uses: joshbeard/docker-hub-tag-delete@dev
+        with:
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_TOKEN }}
+          dockerhub_repository: joshbeard/ansible
+          markdown_file: README.md
+

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ image.
 ## Tags
 
 * `6.4.0`, `6`, `latest`
+* [See all tags](https://hub.docker.com/r/joshbeard/ansible/tags)
 
-__Note:__ This Docker image will maintain tags that are supported upstream, as
-listed in the [Ansible Releases and Maintenance](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html)
-document.
+Refer to the [Tag End of Life and Deletion](#tag-end-of-life-and-deletion)
+section below for information about deprecated image tags.
 
 ### Ansible Release Notes
 
@@ -52,3 +52,22 @@ at `/home/ansible`.
 ## Maintainers
 
 * Josh Beard, <https://joshbeard.me>
+
+## Tag End of Life and Deletion
+
+This Docker image will maintain tags that are supported upstream, as
+listed in the [Ansible Releases and Maintenance](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html)
+document.
+
+The following tags are for versions that have reached end of life and will be
+deleted in the future:
+
+<!-- BEGIN deletion_table -->
+| Tag        | Deletion Date
+| ---------- | ----------------------
+| `2.10.7`   | April 24, 2023
+| `3.4.0`    | April 24, 2023
+| `4.0.0`    | April 24, 2023
+| `5`, `5.*` | October 6, 2023
+<!-- END deletion_table -->
+


### PR DESCRIPTION
This adds a table to the README.md file with dates that old/EOL tags will be deleted.

In addition, a GitHub workflow is added that uses my action from https://github.com/joshbeard/docker-hub-tag-delete to delete specified tags at a specified date based on that Markdown table in the README.