### PR TITLE
Ansible 8.1.0, 7.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,15 +17,11 @@ jobs:
       matrix:
         include:
           -
-            tags: 'joshbeard/ansible:8.0.0,joshbeard/ansible:8,joshbeard/ansible:latest'
-            build-args: ansible_version=8.0.0
+            tags: 'joshbeard/ansible:8.1.0,joshbeard/ansible:8,joshbeard/ansible:latest'
+            build-args: ansible_version=8.1.0
           -
-            tags: 'joshbeard/ansible:7.6.0,joshbeard/ansible:7'
-            build-args: ansible_version=7.6.0
-          -
-            tags: 'joshbeard/ansible:6.6.0,joshbeard/ansible:6'
-            build-args: ansible_version=6.6.0
-
+            tags: 'joshbeard/ansible:7.7.0,joshbeard/ansible:7'
+            build-args: ansible_version=7.7.0
     steps:
       -
         name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN groupadd -g $USER_GID ansible \
   --shell /bin/bash \
   ansible
 
-ARG ansible_version=8.0.0
+ARG ansible_version=8.1.0
 RUN pip3 install --no-cache-dir ansible==${ansible_version}
 
 USER ansible

--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ image.
 
 ## Tags
 
-* `8.0.0`, `8`, `latest`
-* `7.6.0`, `7`
-* `6.6.0`, `6`
+* `8.0.0`, `8`, `latest` (current)
+* `7.7.0`, `7` (end of life)
 * [See all tags](https://hub.docker.com/r/joshbeard/ansible/tags)
 
 Refer to the [Tag End of Life and Deletion](#tag-end-of-life-and-deletion)
@@ -30,8 +29,6 @@ section below for information about deprecated image tags.
 ### Ansible Release Notes
 
 * [Ansible v8 Release Notes](https://github.com/ansible-community/ansible-build-data/blob/main/6/CHANGELOG-v8.rst)
-* [Ansible v7 Release Notes](https://github.com/ansible-community/ansible-build-data/blob/main/6/CHANGELOG-v7.rst)
-* [Ansible v6 Release Notes](https://github.com/ansible-community/ansible-build-data/blob/main/6/CHANGELOG-v6.rst)
 * [Ansible Releases and Maintenance](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html)
 * [Ansible Announcements Google Group](https://groups.google.com/g/ansible-announce)
 * [Ansible package on PyPI](https://pypi.org/project/ansible/)
@@ -68,11 +65,9 @@ The following tags are for versions that have reached end of life and will be
 the specified date.
 
 <!-- BEGIN deletion_table -->
-| Tag        | Deletion Date
-| ---------- | ----------------------
-| `2.10.7`   | April 24, 2023
-| `3.4.0`    | April 24, 2023
-| `4.0.0`    | April 24, 2023
-| `5`, `5.*` | October 6, 2023
+| Tag            | Deletion Date
+| -------------- | ----------------------
+| `5`, `5.*`     | October 6, 2023
+| `6.6.0`, `6.*` | October 6, 2023
 <!-- END deletion_table -->
 


### PR DESCRIPTION
* Build Ansible 8.1.0 image, released June 22, 2023
* Build Ansible 7.7.0, the last 7.x release and now EOL.
* Discontinue 6.x and set for deletion in October (EOL)