### PR TITLE
docs: Fix 8 tag; add v7 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ image.
 
 ## Tags
 
-* `8.0.0`, `8`, `latest` (current)
+* `8.1.0`, `8`, `latest` (current)
 * `7.7.0`, `7` (end of life)
 * [See all tags](https://hub.docker.com/r/joshbeard/ansible/tags)
 
@@ -29,6 +29,7 @@ section below for information about deprecated image tags.
 ### Ansible Release Notes
 
 * [Ansible v8 Release Notes](https://github.com/ansible-community/ansible-build-data/blob/main/6/CHANGELOG-v8.rst)
+* [Ansible v7 Release Notes](https://github.com/ansible-community/ansible-build-data/blob/main/6/CHANGELOG-v7.rst)
 * [Ansible Releases and Maintenance](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html)
 * [Ansible Announcements Google Group](https://groups.google.com/g/ansible-announce)
 * [Ansible package on PyPI](https://pypi.org/project/ansible/)
@@ -65,9 +66,10 @@ The following tags are for versions that have reached end of life and will be
 the specified date.
 
 <!-- BEGIN deletion_table -->
-| Tag            | Deletion Date
-| -------------- | ----------------------
-| `5`, `5.*`     | October 6, 2023
-| `6.6.0`, `6.*` | October 6, 2023
+| Tag        | Deletion Date
+| ---------- | ----------------------
+| `5`, `5.*` | October 6, 2023
+| `6`, `6.*` | October 6, 2023
+| `7`, `7.*` | December 1, 2023
 <!-- END deletion_table -->
 


### PR DESCRIPTION
* Fix the 8.1.0 tag
* Add the v7 notes back to the Readme - it's still a published tag
* Scheduled 7* for deletion on Dec 1